### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=This is a library for using the EZRadio SI4455 Wireless Tranciever Chip
 paragraph=ezradio configuration to tx or rx direct mode
 category=Communication
 url=https://github.com/deeplyembeddedWP/EZRadio_SI4455-Library
-architecture=ESP8266
+architectures=ESP8266
 includes=EZRadio_Si4455.h,si4455_defs.h,si4455_patch.h,Si4455_radio_config.h


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format