### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=This is a library for using the EZRadio SI4455 Wireless Tranciever Chip
 paragraph=ezradio configuration to tx or rx direct mode
 category=Communication
 url=https://github.com/deeplyembeddedWP/EZRadio_SI4455-Library
-architectures=ESP8266
+architectures=esp8266
 includes=EZRadio_Si4455.h,si4455_defs.h,si4455_patch.h,Si4455_radio_config.h


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library EZRadio_SI4455-Library claims to run on (ESP8266) architecture(s) and may be incompatible with your current board which runs on (esp8266) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.